### PR TITLE
Prefer plural variant of testing directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Folder Structure Conventions
     ├── build                   # Compiled files (alternatively `dist`)
     ├── docs                    # Documentation files (alternatively `doc`)
     ├── src                     # Source files (alternatively `lib` or `app`)
-    ├── test                    # Automated tests (alternatively `spec` or `tests`)
+    ├── tests                   # Automated tests (alternatively `spec` or `test`)
     ├── tools                   # Tools and utilities
     ├── LICENSE
     └── README.md


### PR DESCRIPTION
**Rationale**
You have a program's source code, docs, support tools and tests. In line with this nomenclature, `tests` directory name should be preferred over `test`.

FWIW, I don't really care all that much about this. So, consider this a mere suggestion.